### PR TITLE
Add support for Electron 2 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash.template": "^4.4.0",
     "nodeify": "^1.0.1",
     "pify": "^3.0.0",
+    "semver": "^5.5.0",
     "tmp-promise": "^1.0.3",
     "which": "^1.3.0",
     "yargs": "^11.0.0"


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Electron 2.x requires GTK3 instead of GTK2.