### PR TITLE
feat: always set the browser sandbox feature for Electron >= 5.0.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -149,8 +149,9 @@ Available features:
 
 * `audio` - PulseAudio support
 * `alsa` - ALSA support *(replaces `audio` support if both are specified)*
-* `browserSandbox` - [web browser functionality](https://github.com/snapcore/snapd/wiki/Interfaces#browser-support)
-  (e.g., Brave)
+* `browserSandbox` - [web browser functionality](https://github.com/snapcore/snapd/wiki/Interfaces#browser-support).
+  This is enabled by default when using Electron ≥ 5.0.0, due to the
+  [setuid sandbox support](https://github.com/electron/electron/pull/17269).
 * `mpris` - [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/) support. If enabled,
   the interface name must be specified as the feature value.
 * `passwords` - Access the secret service (e.g., GNOME Keyring)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "cross-spawn-promise": "^0.10.1",
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.6.1",
+    "electron-installer-common": "electron-userland/electron-installer-common#separate-sandbox-helper-function",
     "fs-extra": "^7.0.1",
     "js-yaml": "^3.10.0",
     "lodash.filter": "^4.6.0",
@@ -52,6 +52,7 @@
     "lodash.pull": "^4.1.0",
     "nodeify": "^1.0.1",
     "pify": "^4.0.1",
+    "semver": "^6.0.0",
     "tmp-promise": "^1.0.3",
     "which": "^1.3.0",
     "yargs": "^13.2.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "cross-spawn-promise": "^0.10.1",
     "debug": "^4.1.1",
-    "electron-installer-common": "electron-userland/electron-installer-common#separate-sandbox-helper-function",
+    "electron-installer-common": "^0.6.3",
     "fs-extra": "^7.0.1",
     "js-yaml": "^3.10.0",
     "lodash.filter": "^4.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const copyIcon = require('./icon')
 const { copyLauncher } = require('./launcher')
 const createYamlFromTemplate = require('./yaml')
 const defaultArgsFromApp = require('./default_args')
+const { updateSandboxHelperPermissions } = require('electron-installer-common')
 
 class SnapCreator {
   prepareOptions (userSupplied) {
@@ -88,6 +89,7 @@ class SnapCreator {
     const snapMetaDir = path.join(snapDir, 'snap')
     const snapGuiDir = path.join(snapMetaDir, 'gui')
     return fs.ensureDir(snapGuiDir)
+      .then(() => updateSandboxHelperPermissions(this.packageDir))
       .then(() => createDesktopFile(snapGuiDir, this.config))
       .then(() => copyIcon(snapGuiDir, this.config))
       .then(() => copyLauncher(snapDir, this.config))

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -83,7 +83,7 @@ test('setting both audio and alsa prefers alsa', t =>
 )
 
 test('browserSandbox feature', t =>
-  createYaml(t, { name: 'electronAppName', features: { 'browserSandbox': true } })
+  createYaml(t, { name: 'electronAppName', features: { browserSandbox: true } })
     .then(snapcraftYaml => {
       util.assertNotIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'browser-support', 'browser-support is not in app plugs')
       util.assertIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'browser-sandbox', 'browser-sandbox is in app plugs')
@@ -91,8 +91,16 @@ test('browserSandbox feature', t =>
     })
 )
 
+test('browserSandbox is always on for Electron >= 5.0.0', t =>
+  createYaml(t, { name: 'electronAppName' }, '5.0.0')
+    .then(snapcraftYaml => {
+      util.assertNotIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'browser-support', 'browser-support is not in app plugs')
+      return util.assertIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'browser-sandbox', 'browser-sandbox is in app plugs')
+    })
+)
+
 test('browserSandbox feature with custom plugs', t =>
-  createYaml(t, { name: 'electronAppName', appPlugs: ['foobar'], features: { 'browserSandbox': true }, plugs: { foobar: { interface: 'dbus', name: 'com.example.foobar' } } })
+  createYaml(t, { name: 'electronAppName', appPlugs: ['foobar'], features: { browserSandbox: true }, plugs: { foobar: { interface: 'dbus', name: 'com.example.foobar' } } })
     .then(snapcraftYaml => {
       util.assertIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'browser-sandbox', 'browser-sandbox is in app plugs')
       util.assertIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'foobar', 'foobar is in app plugs')


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Also sets the SUID permissions appropriately on the sandbox helper before generating the snap file.

All of this is required due to https://github.com/electron/electron/pull/17269.

CC: @nornagon