### PR TITLE
fix: depend on pulseaudio, not libpulse0

### DIFF
--- a/src/yaml.js
+++ b/src/yaml.js
@@ -35,7 +35,7 @@ const DEPENDENCY_MAP = {
 
 const FEATURES = {
   audio: {
-    packages: ['libpulse0'],
+    packages: ['pulseaudio'],
     plugs: ['pulseaudio']
   },
   alsa: {

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -63,13 +63,13 @@ test('set feature on app', async t => {
     }
   }
   const snapcraftYaml = await createYaml(t, userDefined)
-  util.assertIncludes(t, snapcraftYaml.parts.electronAppName['stage-packages'], 'libpulse0', 'libpulse0 is in stage-packages')
+  util.assertIncludes(t, snapcraftYaml.parts.electronAppName['stage-packages'], 'pulseaudio', 'pulseaudio is in stage-packages')
   util.assertIncludes(t, snapcraftYaml.apps.electronAppName.plugs, 'pulseaudio', 'pulseaudio is in app plugs')
 })
 
 test('setting both audio and alsa prefers alsa', async t => {
   const { apps, parts } = await createYaml(t, { name: 'electronAppName', features: { 'audio': true, 'alsa': true } })
-  util.assertNotIncludes(t, parts.electronAppName['stage-packages'], 'libpulse0', 'libpulse0 is not in stage-packages')
+  util.assertNotIncludes(t, parts.electronAppName['stage-packages'], 'pulseaudio', 'pulseaudio is not in stage-packages')
   util.assertNotIncludes(t, apps.electronAppName.plugs, 'pulseaudio', 'pulseaudio is not in app plugs')
   util.assertIncludes(t, parts.electronAppName['stage-packages'], 'libasound2', 'libasound2 is in stage-packages')
   util.assertIncludes(t, apps.electronAppName.plugs, 'alsa', 'alsa is in app plugs')


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Electron has a dependency on `libasound2`. If you need Pulseaudio support, you'll need `pulseaudio` anyway. This has the side benefit of also requiring `libasound2`.