### PR TITLE
feat: autodetect base when not specified by the user

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "nyc": "^14.0.0"
+    "nyc": "^14.0.0",
+    "sinon": "^7.5.0"
   },
   "dependencies": {
     "cross-spawn-promise": "^0.10.1",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Autodetect the [`base`](https://snapcraft.io/docs/snapcraft-top-level-metadata#heading--base) setting if it's not specified, based on the host machine's distro information.