### PR TITLE
refactor: replace cross-spawn-promise with spawn in electron-installer-common

### DIFF
--- a/ci/install_snap_dependencies.sh
+++ b/ci/install_snap_dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+sudo apt update
+
 mkdir -p fakesnap/snap
 cp ci/snapcraft.yaml fakesnap/snap/
 pushd fakesnap

--- a/package.json
+++ b/package.json
@@ -44,9 +44,8 @@
     "sinon": "^8.0.4"
   },
   "dependencies": {
-    "cross-spawn-promise": "^0.10.1",
     "debug": "^4.1.1",
-    "electron-installer-common": "^0.9.0",
+    "electron-installer-common": "^0.10.0",
     "fs-extra": "^8.0.1",
     "js-yaml": "^3.10.0",
     "lodash": "^4.17.15",

--- a/src/snapcraft.js
+++ b/src/snapcraft.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 const debug = require('debug')('electron-installer-snap:snapcraft')
-const spawn = require('cross-spawn-promise')
+const { spawn } = require('electron-installer-common')
 const which = require('which')
 
 class Snapcraft {

--- a/src/yaml.js
+++ b/src/yaml.js
@@ -21,7 +21,6 @@ const fs = require('fs-extra')
 const { merge, pull } = require('lodash')
 const path = require('path')
 const semver = require('semver')
-const spawn = require('cross-spawn-promise')
 const which = require('which')
 const yaml = require('js-yaml')
 
@@ -101,7 +100,7 @@ class SnapcraftYAML {
   }
 
   async detectDistro (lsbRelease) {
-    const output = await spawn(lsbRelease, ['--short', '--id', '--release'])
+    const output = await common.spawn(lsbRelease, ['--short', '--id', '--release'])
     if (output) {
       return output.toString().trim().split('\n')
     }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`cross-spawn-promise` does not seem to be maintained, as the `cross-spawn` dependency is a couple of major versions behind and the last commit to the repository was over two years ago.

### TODO

* [x] Merge/release spawn refactor in `electron-installer-common`
* [x] Update `electron-installer-common` dependency