### PR TITLE
fix: clarify the use of SnapcraftConfig

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,8 +29,7 @@
 declare function createSnap(userSupplied: createSnap.Options & createSnap.SnapcraftConfig): Promise<string>;
 
 declare namespace createSnap {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type SnapcraftConfig = Record<string, any>;
+  type SnapcraftConfig = Record<string, unknown>;
   /**
    * Any options that aren't specified here are passed through to the `snapcraft.yaml` file.
    */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,16 +29,21 @@
 declare function createSnap(userSupplied: createSnap.Options & createSnap.SnapcraftConfig): Promise<string>;
 
 declare namespace createSnap {
+  /**
+   * Additional Snapcraft configuration that is merged directly into `snapcraft.yaml`. In general,
+   * this does not override any configuration that is set via [[Options]].
+   */
   type SnapcraftConfig = Record<string, unknown>;
   /**
-   * Any options that aren't specified here are passed through to the `snapcraft.yaml` file.
+   * Any options that aren't specified here are passed through to the `snapcraft.yaml` file via [[SnapcraftConfig]].
    */
   interface Options {
     src: string;
 
     /**
-     * [Additional Snapcraft configuration](https://docs.snapcraft.io/build-snaps/syntax#app-name)
-     * for the Electron app.
+     * [Additional app-specific Snapcraft configuration](https://docs.snapcraft.io/build-snaps/syntax#app-name)
+     * for the Electron app. This is different from [[SnapcraftConfig]] in that it is scoped
+     * under `apps.<app-name>`.
      */
     appConfig?: object;
     /**


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Use a more recommended type definition for `SnapcraftConfig`
* Clarify the difference between `SnapcraftConfig` and `Options.appConfig`