### PR TITLE
build(ci): use Codecov Action instead of devDependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
       - name: Test
         run: npm run coverage
         env:
-          CI: true
           DEBUG: electron-installer-snap:snapcraft
-      - name: Codecov
-        run: npm run codecov
+      - name: Upload code coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.lcov
+          env_vars: NODE_VERSION
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.lcov
 *.log
 .nyc_output
 node_modules

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   ],
   "scripts": {
     "ava": "ava",
-    "codecov": "nyc report --reporter=text-lcov | codecov --disable=gcov --pipe",
-    "coverage": "nyc ava",
+    "coverage": "nyc ava && nyc report --reporter=text-lcov > coverage.lcov",
     "docs:build": "node ci/build_docs.js",
     "eslint:js": "eslint .",
     "eslint:ts": "eslint --ext .ts --config .eslintrc.typescript.js .",
@@ -39,7 +38,6 @@
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "ava": "^3.0.0",
-    "codecov": "^3.1.0",
     "cross-env": "^7.0.0",
     "eslint": "^6.0.1",
     "eslint-config-standard": "^14.0.0",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Less to install when developing locally.