### PR TITLE
chore: allow disabling browser sandbox

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,10 +157,12 @@ declare namespace createSnap {
       alsa?: true;
       /**
        * [Web browser functionality](https://github.com/snapcore/snapd/wiki/Interfaces#browser-support).
-       * This is enabled by default when using Electron ≥ 5.0.0, due to the
+       * This was originally enabled by default when using Electron ≥ 5.0.0, due to the
        * [setuid sandbox support](https://github.com/electron/electron/pull/17269).
+       * However, Snapcraft allows for use of the snap confined sandbox, particularly within
+       * strict confinement. We should encourage but not enforce the browser-sandbox plug.
        */
-      browserSandbox?: true;
+      browserSandbox?: false;
       /**
        * [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/) support.
        *

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -85,10 +85,10 @@ test('browserSandbox feature', async t => {
   t.deepEqual(plugs['browser-sandbox'], { interface: 'browser-support', 'allow-sandbox': true }, 'browser-sandbox plug exists')
 })
 
-test('browserSandbox is always on for Electron >= 5.0.0', async t => {
-  const { apps } = await createYaml(t, { name: 'electronAppName' }, '5.0.0')
-  util.assertNotIncludes(t, apps.electronAppName.plugs, 'browser-support', 'browser-support is not in app plugs')
-  util.assertIncludes(t, apps.electronAppName.plugs, 'browser-sandbox', 'browser-sandbox is in app plugs')
+test('browserSandbox feature allow both true and false', async t => {
+  const { apps } = await createYaml(t, { name: 'electronAppName', features: { browserSandbox: false } })
+  util.assertIncludes(t, apps.electronAppName.plugs, 'browser-support', 'browser-support is not in app plugs')
+  util.assertNotIncludes(t, apps.electronAppName.plugs, 'browser-sandbox', 'browser-sandbox is in app plugs')
 })
 
 test('browserSandbox feature with custom plugs', async t => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-installer-snap/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
This PR does not force the `browser-sandbox` interface to `true`. Having this sandbox requires a manual review in the Snap store, and is not used by many large Electron apps. In strict confinement mode, Electron apps can instead use the snap's confinement.

We'll be moving the template from a default of classic to strict in the future, but this change will allow apps to build for the snap store and pass review without manual changes.
